### PR TITLE
NP-2663 limit prerender to nakd

### DIFF
--- a/NaKd.Prerender.io/PrerenderModule.cs
+++ b/NaKd.Prerender.io/PrerenderModule.cs
@@ -145,6 +145,8 @@ namespace NaKd.Prerender.io
 				url = url.Replace(request.ApplicationPath, string.Empty);
 			}
 
+            url = RemoveUtmQueryStrings(url);
+
             var appendUrl = url.IndexOf("?") >= 0 ? "&ssr=on" : "?ssr=on";
 
             if (ShouldAddMobileParameter(request))
@@ -157,8 +159,29 @@ namespace NaKd.Prerender.io
                 ? (prerenderServiceUrl + url + appendUrl)
                 : string.Format("{0}/{1}{2}", prerenderServiceUrl, url, appendUrl);
         }
+
+        public static string RemoveUtmQueryStrings(string url)
+        {
+            var newUrl = url;
+            MatchCollection matches = Regex.Matches(url, "(?!&)utm_[^=]*");
+
+            if(matches.Count == 0)
+            {
+                return url;
+            }
+
+            foreach (Match match in matches)
+            {
+                foreach (Capture capture in match.Captures)
+                {
+                    newUrl = RemoveQueryStringByKey(newUrl, capture.Value);
+                }
+            }
+
+            return newUrl;
+        }
 	
-	public static string RemoveQueryStringByKey(string url, string key)
+	    public static string RemoveQueryStringByKey(string url, string key)
         {
             var uri = new Uri(url);
 

--- a/NaKd.Prerender.io/Properties/AssemblyInfo.cs
+++ b/NaKd.Prerender.io/Properties/AssemblyInfo.cs
@@ -15,5 +15,5 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("DA92FF4E-F7A7-4276-B317-7B2CA4105EC0")]
 
-[assembly: AssemblyVersion("1.0.0.4")]
-[assembly: AssemblyFileVersion("1.0.0.4")]
+[assembly: AssemblyVersion("1.0.0.5")]
+[assembly: AssemblyFileVersion("1.0.0.5")]


### PR DESCRIPTION
Issue: https://na-kd-com.atlassian.net/browse/NP-2663

Stripping "utm_"-parameters from the url to prevent marketing from caching own Prerender pages.

Also updated AssemblyVersion to 1.0.0.5