### PR TITLE
NP-3027 Remove ssr and mobile parameters before adding them again, to prevent duplicates

### DIFF
--- a/NaKd.Prerender.io/PrerenderModule.cs
+++ b/NaKd.Prerender.io/PrerenderModule.cs
@@ -146,11 +146,12 @@ namespace NaKd.Prerender.io
 			}
 
             url = RemoveUtmQueryStrings(url);
-
+            url = RemoveQueryStringByKey(url, "ssr");
             var appendUrl = url.IndexOf("?") >= 0 ? "&ssr=on" : "?ssr=on";
 
             if (ShouldAddMobileParameter(request))
             {
+                url = RemoveQueryStringByKey(url, "mobile");
                 appendUrl = url.IndexOf("?") >= 0 ? "&mobile=1&ssr=on" : "?mobile=1&ssr=on";
             }
 

--- a/NaKd.Prerender.io/Properties/AssemblyInfo.cs
+++ b/NaKd.Prerender.io/Properties/AssemblyInfo.cs
@@ -15,5 +15,5 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("DA92FF4E-F7A7-4276-B317-7B2CA4105EC0")]
 
-[assembly: AssemblyVersion("1.0.0.5")]
-[assembly: AssemblyFileVersion("1.0.0.5")]
+[assembly: AssemblyVersion("1.0.0.6")]
+[assembly: AssemblyFileVersion("1.0.0.6")]


### PR DESCRIPTION
Prerender would sometimes index duplicate urls, the duplicate would have a 2nd `ssr` query parameter.
This attempts to fix that by first removing the parameter before adding it.

Jira: https://na-kd-com.atlassian.net/browse/NP-3027